### PR TITLE
Add auto-orient option 

### DIFF
--- a/lib/paperclip-watermark/watermark.rb
+++ b/lib/paperclip-watermark/watermark.rb
@@ -8,56 +8,24 @@
 # require 'paperclip_processors/watermark'
 
 module Paperclip
-  class Watermark < Processor
+  class Watermark < Thumbnail
     # Handles watermarking of images that are uploaded.
-    attr_accessor :current_geometry, :target_geometry, :format, :whiny, :convert_options, :watermark_path, :overlay, :position
+    attr_accessor :watermark_path, :overlay, :position
 
     def initialize file, options = {}, attachment = nil
       super
-      geometry          = options[:geometry]
-      @file             = file
-      if geometry.present?
-        @crop             = geometry[-1,1] == '#'
-      end
-      @target_geometry  = Geometry.parse geometry
-      @current_geometry = Geometry.from_file @file
-      @convert_options  = options[:convert_options]
-      @whiny            = options[:whiny].nil? ? true : options[:whiny]
-      @format           = options[:format]
+      
       @watermark_path   = options[:watermark_path]
       @position         = options[:position].nil? ? "SouthEast" : options[:position]
       @overlay          = options[:overlay].nil? ? true : false
-      @current_format   = File.extname(@file.path)
-      @basename         = File.basename(@file.path, @current_format)
     end
 
     # TODO: extend watermark
 
-    # Returns true if the +target_geometry+ is meant to crop.
-    def crop?
-      @crop
-    end
-
-    # Returns true if the image is meant to make use of additional convert options.
-    def convert_options?
-      not [*@convert_options].reject(&:blank?).empty?
-    end
-
     # Performs the conversion of the +file+ into a watermark. Returns the Tempfile
     # that contains the new image.
     def make
-      dst = Tempfile.new([@basename, @format].compact.join("."))
-      dst.binmode
-
-      command = "convert"
-      params = [fromfile]
-      params += transformation_command
-      params << tofile(dst)
-      begin
-        success = Paperclip.run(command, params.flatten.compact.collect{|e| "'#{e}'"}.join(" "))
-      rescue Paperclip::Errors::CommandNotFoundError
-        raise Paperclip::Errors::CommandNotFoundError, "There was an error resizing and cropping #{@basename}" if @whiny
-      end
+      dst = super
 
       if watermark_path
         command = "composite"
@@ -73,28 +41,8 @@ module Paperclip
       dst
     end
 
-    def fromfile
-      File.expand_path(@file.path)
-    end
-
     def tofile(destination)
       [@format, File.expand_path(destination.path)].compact.join(':')
-    end
-
-    def transformation_command
-      if @target_geometry.present?
-        scale, crop = @current_geometry.transformation_to(@target_geometry, crop?)
-        trans = %W[-resize #{scale}]
-        trans += %W[-crop #{crop} +repage] if crop
-        trans += [*convert_options] if convert_options?
-        trans
-      else
-        scale, crop = @current_geometry.transformation_to(@current_geometry, crop?)
-        trans = %W[-resize #{scale}]
-        trans += %W[-crop #{crop} +repage] if crop
-        trans += [*convert_options] if convert_options?
-        trans
-      end
     end
   end
 end


### PR DESCRIPTION
I noticed this didn't add the `-auto-orient` option, so I started to add it in. As I started to add it, I quickly noticed that the code is very redundant from the `Thumbnail` processor of the original [Paperclip](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/thumbnail.rb) repo. 

So I ended up removing the redundant code and in the process got my `-auto-orient` flag added.
